### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:icon="@mipmap/logo"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>


### PR DESCRIPTION
根据[Network security configuration](https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted)， 安卓9以后自动把cleartext support默认为禁用，这样就导致okhttp无法连接http网页，加的这一行代码是为了重新启用cleartext support